### PR TITLE
Refactoring TodoContext to simplify state

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -4,11 +4,10 @@ import { Appbar, Menu, Divider, TextInput, Portal, Button } from 'react-native-p
 import { useTodoContext } from '../contexts/TodoContext';
 
 const Header = () => {
-  const { listUuid, lists, changeList, addList } = useTodoContext();
+  const { lists, currentList, changeList, addList } = useTodoContext();
   const [menuVisible, setMenuVisible] = useState(false);
   const [addListViewVisible, setAddListViewVisible] = useState(false);
   const [newListName, setNewListName] = useState('');
-  const currentList = lists.find((list) => list.uuid === listUuid);
 
   const handleMenuOpen = useCallback(() => {
     setMenuVisible(true);
@@ -52,7 +51,7 @@ const Header = () => {
             <Menu.Item
               key={list.uuid}
               title={list.name}
-              onPress={() => handleListChange(list.uuid)}
+              onPress={() => handleListChange(list)}
             />
           ))}
           <Divider />

--- a/src/components/TodoList.js
+++ b/src/components/TodoList.js
@@ -4,22 +4,22 @@ import { Checkbox } from 'react-native-paper';
 import { useTodoContext } from '../contexts/TodoContext';
 
 const TodoList = () => {
-  const { list, completeItem } = useTodoContext();
+  const { currentItems, completeItem } = useTodoContext();
 
   const sortedList = useMemo(() => {
-    const incompleteItems = list.filter((item) => !item.complete);
-    const completeItems = list.filter((item) => item.complete);
+    const incompleteItems = currentItems.filter((item) => !item.complete);
+    const completeItems = currentItems.filter((item) => item.complete);
     return [...incompleteItems, ...completeItems];
-  }, [list]);
+  }, [currentItems]);
 
   return (
     <ScrollView>
       {sortedList.map((item) => (
         <Checkbox.Item
           key={item.uuid}
-          label={item.description}
+          label={item.name}
           status={item.complete ? 'checked' : 'unchecked'}
-          onPress={() => completeItem(item.uuid)}
+          onPress={() => completeItem(item)}
         />
       ))}
     </ScrollView>


### PR DESCRIPTION
This PR: 
- Removes the `list` and `listUuid` state properties, and adds `currentList` and `currentItems` to replace them. This simplifies things for the down stream components.  Also makes it easier to digest for someone reviewing the code.
- Stops passing around `uuid`, and instead passing complete entity objects. This keeps the complexity down, and also makes it more simple to work with properties other than `uuid`
- Refactors a good deal of the logic within `TodoContext`. Mostly related to the first point. Things include making method names more descriptive, and reusable.
 

 