### PR TITLE
Updating metro config file

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,14 +1,7 @@
-const {getDefaultConfig} = require('metro-config');
+const { getDefaultConfig } = require('expo/metro-config');
 
-module.exports = (async () => {
-  const {
-    resolver: {sourceExts, assetExts},
-  } = await getDefaultConfig();
-  return {
-    resolver: {
-      assetExts: assetExts.filter((ext) => ext !== 'svg'),
-      sourceExts: [...sourceExts, 'ts', 'tsx'],
-    },
-  };
-})();
+const config = getDefaultConfig(__dirname);
 
+config.resolver.sourceExts.push('ts', 'tsx');
+
+module.exports = config;


### PR DESCRIPTION
This PR updates the metro config file to use the latest expected format and path to module.  I think this current state snuck in while referencing the web to get typescript to play nice, but appears to be an older format.