### PR TITLE
Adding ability to delete current list

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,12 +7,13 @@ import {
   TouchableOpacity,
   TextInput,
   Image,
+  Alert,
 } from 'react-native';
 import { useTodoContext } from '../contexts/TodoContext';
 import { List } from '../shared/types';
 
 const Header = () => {
-  const { lists, currentList, changeList, addList } = useTodoContext();
+  const { lists, currentList, changeList, addList, deleteList } = useTodoContext();
   const [menuVisible, setMenuVisible] = useState(false);
   const [addListViewVisible, setAddListViewVisible] = useState(false);
   const [newListName, setNewListName] = useState('');
@@ -41,9 +42,36 @@ const Header = () => {
     setAddListViewVisible(false);
   }, [addList, newListName]);
 
+  const handleDeleteList = useCallback(() => {
+    Alert.alert(
+      'Delete List',
+      'Are you sure you want to delete this list?',
+      [
+        {
+          text: 'Cancel',
+        },
+        {
+          text: 'OK',
+          onPress: () => {
+            if (currentList) {
+              deleteList(currentList);
+            }
+          },
+        },
+      ],
+      { cancelable: false }
+    );
+  }, [currentList, deleteList]);
+
   return (
     <>
       <View style={styles.header} testID="header">
+        <TouchableOpacity
+          onPress={handleDeleteList}
+          testID="deleteListButton"
+        >
+          <Text>Delete</Text>
+        </TouchableOpacity>
         <Text style={styles.title}>{currentList?.name}</Text>
         <TouchableOpacity
           onPress={handleMenuOpen}

--- a/src/contexts/TodoContext.tsx
+++ b/src/contexts/TodoContext.tsx
@@ -11,6 +11,7 @@ interface TodoContextData {
   completeItem: (item: Item) => Promise<void>;
   changeList: (list: List) => void;
   addList: (name: string) => Promise<void>;
+  deleteList: (list: List) => Promise<void>;
 }
 
 const TodoContext = createContext<TodoContextData | null>(null);
@@ -103,6 +104,25 @@ export const TodoProvider = ({ children }: TodoProviderProps) => {
     }
   };
 
+  const deleteList = async (listToDelete: List) => {
+    try {
+      await AsyncStorage.removeItem(listToDelete.uuid);
+      const updatedLists = lists.filter((list) => list.uuid !== listToDelete.uuid);
+
+      if (updatedLists.length === 0) {
+        const defaultList = { name: DEFAULT_LIST_NAME, uuid: uuid.v4() };
+        updatedLists.push(defaultList);
+      }
+
+      setLists(updatedLists);
+      await AsyncStorage.setItem('lists', JSON.stringify(updatedLists));
+
+      setCurrentListAndLoadItems(updatedLists[0]);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   return (
     <TodoContext.Provider
       value={{
@@ -113,6 +133,7 @@ export const TodoProvider = ({ children }: TodoProviderProps) => {
         completeItem,
         changeList,
         addList,
+        deleteList,
       }}
     >
       {children}


### PR DESCRIPTION
This PR adds a new "Delete" button to the header of the app which will delete the current list via a confirmation alert dialog.

This alert is a native feature so it's not as nice of a testing experience.  It seems the only option is to "spy" on `Alert.alert` and call the `onPress` method assigned to the mock by the code itself.  Also the means of doing this make typescript upset, so it needs to be ignored.

<img width="445" alt="image" src="https://user-images.githubusercontent.com/17733382/234052914-d3633c3c-aa09-438e-abd6-c5432ed09608.png">
<img width="407" alt="image" src="https://user-images.githubusercontent.com/17733382/234052943-e00dad1f-5f7a-4c06-a720-0ec8f8442738.png">
